### PR TITLE
feat: 아우누리 포털 로그인 로직 마이그레이션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ out/
 .DS_STORE
 
 application.yml
+application-portal.yml
 *adminsdk.json
 
 logs

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
 
+	// okhttp
+	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+	implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.12.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
 

--- a/src/main/java/in/koreatech/batch/_common/auth/exception/AuthenticationException.java
+++ b/src/main/java/in/koreatech/batch/_common/auth/exception/AuthenticationException.java
@@ -1,0 +1,20 @@
+package in.koreatech.batch._common.auth.exception;
+
+import in.koreatech.batch._common.exception.custom.KoinException;
+
+public class AuthenticationException extends KoinException {
+
+    private static final String DEFAULT_MESSAGE = "올바르지 않은 인증정보입니다.";
+
+    public AuthenticationException(String message) {
+        super(message);
+    }
+
+    public AuthenticationException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AuthenticationException withDetail(String detail) {
+        return new AuthenticationException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/auth/exception/AuthorizationException.java
+++ b/src/main/java/in/koreatech/batch/_common/auth/exception/AuthorizationException.java
@@ -1,0 +1,20 @@
+package in.koreatech.batch._common.auth.exception;
+
+import in.koreatech.batch._common.exception.custom.KoinException;
+
+public class AuthorizationException extends KoinException {
+
+    private static final String DEFAULT_MESSAGE = "권한이 없습니다.";
+
+    public AuthorizationException(String message) {
+        super(message);
+    }
+
+    public AuthorizationException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AuthorizationException withDetail(String detail) {
+        return new AuthorizationException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/config/DataDBConfig.java
+++ b/src/main/java/in/koreatech/batch/_common/config/DataDBConfig.java
@@ -1,4 +1,4 @@
-package in.koreatech.batch.config;
+package in.koreatech.batch._common.config;
 
 import java.util.HashMap;
 

--- a/src/main/java/in/koreatech/batch/_common/config/DataDBProperties.java
+++ b/src/main/java/in/koreatech/batch/_common/config/DataDBProperties.java
@@ -1,4 +1,4 @@
-package in.koreatech.batch.config;
+package in.koreatech.batch._common.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/in/koreatech/batch/_common/config/MetaDBConfig.java
+++ b/src/main/java/in/koreatech/batch/_common/config/MetaDBConfig.java
@@ -1,4 +1,4 @@
-package in.koreatech.batch.config;
+package in.koreatech.batch._common.config;
 
 import javax.sql.DataSource;
 

--- a/src/main/java/in/koreatech/batch/_common/config/OkHttpClientConfig.java
+++ b/src/main/java/in/koreatech/batch/_common/config/OkHttpClientConfig.java
@@ -1,0 +1,29 @@
+package in.koreatech.batch._common.config;
+
+import static java.net.CookiePolicy.ACCEPT_ALL;
+
+import java.net.CookieManager;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+import okhttp3.JavaNetCookieJar;
+import okhttp3.OkHttpClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class OkHttpClientConfig {
+
+    @Bean
+    public OkHttpClient okHttpClient() {
+        return new OkHttpClient.Builder()
+            .cookieJar(new JavaNetCookieJar(cookieManager()))
+            .build();
+    }
+
+    @Bean
+    public CookieManager cookieManager() {
+       return new CookieManager(null, ACCEPT_ALL);
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/config/RedisConfig.java
+++ b/src/main/java/in/koreatech/batch/_common/config/RedisConfig.java
@@ -1,0 +1,71 @@
+package in.koreatech.batch._common.config;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+@Profile("!test")
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(mapper);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setConnectionFactory(connectionFactory);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+        return template;
+    }
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        /*
+        1. content-type: text/html
+        2. body는 json
+
+        위 조건일 경우, 파싱이 안되고 UnknownContentTypeException 발생하는 문제 해결하기 위해 text/html도 지원 목록에 추가
+        */
+        MappingJackson2HttpMessageConverter jacksonConverter = new MappingJackson2HttpMessageConverter();
+        jacksonConverter.setSupportedMediaTypes(List.of(
+            MediaType.TEXT_HTML,
+            MediaType.APPLICATION_JSON
+        ));
+
+        return restTemplateBuilder.
+            requestFactory(() -> new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())).
+            setConnectTimeout(Duration.ofMillis(5000))
+            .setReadTimeout(Duration.ofMillis(5000))
+            .additionalMessageConverters(
+                jacksonConverter,
+                new StringHttpMessageConverter(UTF_8)
+            )
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/exception/ErrorResponse.java
+++ b/src/main/java/in/koreatech/batch/_common/exception/ErrorResponse.java
@@ -1,0 +1,22 @@
+package in.koreatech.batch._common.exception;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+    @JsonIgnore
+    private final int status;
+    private final int code;
+    private final String message;
+    private final String errorTraceId;
+
+    public ErrorResponse(int status, String message, String errorTraceId) {
+        this.status = status;
+        this.code = 0;
+        this.message = message;
+        this.errorTraceId = errorTraceId;
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/batch/_common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,327 @@
+package in.koreatech.batch._common.exception;
+
+import java.time.DateTimeException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.catalina.connector.ClientAbortException;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.lang.Nullable;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.WebUtils;
+
+import in.koreatech.batch._common.auth.exception.AuthenticationException;
+import in.koreatech.batch._common.auth.exception.AuthorizationException;
+import in.koreatech.batch._common.exception.custom.DataNotFoundException;
+import in.koreatech.batch._common.exception.custom.DuplicationException;
+import in.koreatech.batch._common.exception.custom.ExternalServiceException;
+import in.koreatech.batch._common.exception.custom.KoinException;
+import in.koreatech.batch._common.exception.custom.KoinIllegalArgumentException;
+import in.koreatech.batch._common.exception.custom.KoinIllegalStateException;
+import in.koreatech.batch._common.exception.custom.RequestTooFastException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    // 커스텀 예외
+
+    @ExceptionHandler(KoinException.class)
+    public ResponseEntity<Object> handleIllegalArgumentException(
+        HttpServletRequest request,
+        KoinException e
+    ) {
+        log.warn(e.getFullMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(KoinIllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgumentException(
+        HttpServletRequest request,
+        KoinIllegalArgumentException e
+    ) {
+        log.warn(e.getFullMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(KoinIllegalStateException.class)
+    public ResponseEntity<Object> handleIllegalStateException(
+        HttpServletRequest request,
+        KoinIllegalStateException e
+    ) {
+        log.warn(e.getFullMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<Object> handleAuthorizationException(
+        HttpServletRequest request,
+        AuthorizationException e
+    ) {
+        log.warn(e.getFullMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.FORBIDDEN, e.getMessage());
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<Object> handleAuthenticationException(
+        HttpServletRequest request,
+        AuthenticationException e
+    ) {
+        log.warn(e.getFullMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.UNAUTHORIZED, e.getMessage());
+    }
+
+    @ExceptionHandler(DataNotFoundException.class)
+    public ResponseEntity<Object> handleDataNotFoundException(
+        HttpServletRequest request,
+        DataNotFoundException e
+    ) {
+        log.warn(e.getFullMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+    }
+
+    @ExceptionHandler(DuplicationException.class)
+    public ResponseEntity<Object> handleDataNotFoundException(
+        HttpServletRequest request,
+        DuplicationException e
+    ) {
+        log.warn(e.getFullMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.CONFLICT, e.getMessage());
+    }
+
+    @ExceptionHandler(ExternalServiceException.class)
+    public ResponseEntity<Object> handleExternalServiceException(
+        HttpServletRequest request,
+        ExternalServiceException e
+    ) {
+        log.warn(e.getFullMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+    // 표준 예외 및 정의되어 있는 예외
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleRequestTooFastException(
+        HttpServletRequest request,
+        IllegalArgumentException e
+    ) {
+        log.warn(e.getMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Object> handleRequestTooFastException(
+        HttpServletRequest request,
+        IllegalStateException e
+    ) {
+        log.warn(e.getMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(RequestTooFastException.class)
+    public ResponseEntity<Object> handleRequestTooFastException(
+        HttpServletRequest request,
+        RequestTooFastException e
+    ) {
+        log.warn(e.getMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.CONFLICT, e.getMessage());
+    }
+
+    @ExceptionHandler(DateTimeException.class)
+    public ResponseEntity<Object> handleDateTimeParseException(
+        HttpServletRequest request,
+        DateTimeException e
+    ) {
+        log.warn(e.getMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "잘못된 날짜 형식입니다.");
+    }
+
+    @ExceptionHandler(UnsupportedOperationException.class)
+    public ResponseEntity<Object> handleUnsupportedOperationException(
+        HttpServletRequest request,
+        UnsupportedOperationException e
+    ) {
+        log.warn(e.getMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "지원하지 않는 API 입니다.");
+    }
+
+    @ExceptionHandler(ClientAbortException.class)
+    public ResponseEntity<Object> handleClientAbortException(
+        HttpServletRequest request,
+        ClientAbortException e
+    ) {
+        logger.warn("클라이언트가 연결을 중단했습니다: " + e.getMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "클라이언트에 의해 연결이 중단되었습니다");
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+        HttpMessageNotReadableException e,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
+        log.warn(e.getMessage());
+        requestLogging(((ServletWebRequest)request).getRequest());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "잘못된 입력 형식이거나, 값이 허용된 범위를 초과했습니다.");
+    }
+
+    @Override
+    public ResponseEntity<Object> handleNoHandlerFoundException(
+        NoHandlerFoundException e,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
+        log.warn("유효하지 않은 API 경로입니다. {}", e.getRequestURL());
+        requestLogging(((ServletWebRequest)request).getRequest());
+        return buildErrorResponse(HttpStatus.NOT_FOUND, "유효하지 않은 API 경로입니다.");
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<Object> handleOptimisticLockException(
+        HttpServletRequest request,
+        ObjectOptimisticLockingFailureException e
+    ) {
+        log.warn(e.getMessage());
+        requestLogging(((ServletWebRequest)request).getRequest());
+        return buildErrorResponse(HttpStatus.CONFLICT, "이미 처리된 요청입니다.");
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleException(
+        HttpServletRequest request,
+        Exception e
+    ) {
+        String errorMessage = e.getMessage();
+        String errorFile = e.getStackTrace()[0].getFileName();
+        int errorLine = e.getStackTrace()[0].getLineNumber();
+        String errorName = e.getClass().getSimpleName();
+        String detail = String.format("""
+                Exception: *%s*
+                Location: *%s Line %d*
+                
+                ```%s```
+                """,
+            errorName, errorFile, errorLine, errorMessage);
+        log.error("""
+            서버에서 에러가 발생했습니다. uri: {} {}
+            {}
+            """, request.getMethod(), request.getRequestURI(), detail);
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 오류가 발생했습니다.");
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+        MethodArgumentNotValidException e,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest webRequest
+    ) {
+        HttpServletRequest request = ((ServletWebRequest)webRequest).getRequest();
+        log.warn("검증과정에서 문제가 발생했습니다. uri: {} {}, ", request.getMethod(), request.getRequestURI(), e);
+        requestLogging(request);
+        String errorMessages = e.getBindingResult().getAllErrors().stream()
+            .map(DefaultMessageSourceResolvable::getDefaultMessage)
+            .collect(Collectors.joining(", "));
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, errorMessages);
+    }
+
+    // 예외 메시지 구성 로직
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+        Exception e,
+        @Nullable Object body,
+        HttpHeaders headers,
+        HttpStatusCode statusCode,
+        WebRequest request
+    ) {
+        return buildErrorResponse(HttpStatus.valueOf(statusCode.value()), e.getMessage());
+    }
+
+    private ResponseEntity<Object> buildErrorResponse(
+        HttpStatus httpStatus,
+        String message
+    ) {
+        String errorTraceId = UUID.randomUUID().toString();
+        log.warn("traceId: {}", errorTraceId);
+        var response = new ErrorResponse(httpStatus.value(), message, errorTraceId);
+        return ResponseEntity.status(httpStatus).body(response);
+    }
+
+    private void requestLogging(HttpServletRequest request) {
+        log.info("request header: {}", getHeaders(request));
+        log.info("request query string: {}", getQueryString(request));
+        log.info("request body: {}", getRequestBody(request));
+    }
+
+    private Map<String, Object> getHeaders(HttpServletRequest request) {
+        Map<String, Object> headerMap = new HashMap<>();
+        Enumeration<String> headerArray = request.getHeaderNames();
+        while (headerArray.hasMoreElements()) {
+            String headerName = headerArray.nextElement();
+            headerMap.put(headerName, request.getHeader(headerName));
+        }
+        return headerMap;
+    }
+
+    private String getQueryString(HttpServletRequest httpRequest) {
+        String queryString = httpRequest.getQueryString();
+        if (queryString == null) {
+            return " - ";
+        }
+        return queryString;
+    }
+
+    private String getRequestBody(HttpServletRequest request) {
+        var wrapper = WebUtils.getNativeRequest(request, ContentCachingRequestWrapper.class);
+        if (wrapper == null) {
+            return " - ";
+        }
+        try {
+            // body 가 읽히지 않고 예외처리 되는 경우에 캐시하기 위함
+            wrapper.getInputStream().readAllBytes();
+            byte[] buf = wrapper.getContentAsByteArray();
+            if (buf.length == 0) {
+                return " - ";
+            }
+            return new String(buf, wrapper.getCharacterEncoding());
+        } catch (Exception e
+        ) {
+            return " - ";
+        }
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/exception/custom/DataNotFoundException.java
+++ b/src/main/java/in/koreatech/batch/_common/exception/custom/DataNotFoundException.java
@@ -1,0 +1,12 @@
+package in.koreatech.batch._common.exception.custom;
+
+public abstract class DataNotFoundException extends KoinException {
+
+    protected DataNotFoundException(String message) {
+        super(message);
+    }
+
+    protected DataNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/exception/custom/DuplicationException.java
+++ b/src/main/java/in/koreatech/batch/_common/exception/custom/DuplicationException.java
@@ -1,0 +1,12 @@
+package in.koreatech.batch._common.exception.custom;
+
+public abstract class DuplicationException extends KoinException {
+
+    protected DuplicationException(String message) {
+        super(message);
+    }
+
+    protected DuplicationException(String message, String detail) {
+        super(message, detail);
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/exception/custom/ExternalServiceException.java
+++ b/src/main/java/in/koreatech/batch/_common/exception/custom/ExternalServiceException.java
@@ -1,0 +1,12 @@
+package in.koreatech.batch._common.exception.custom;
+
+public abstract class ExternalServiceException extends KoinException {
+
+    protected ExternalServiceException(String message) {
+        super(message);
+    }
+
+    protected ExternalServiceException(String message, String detail) {
+        super(message, detail);
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/exception/custom/KoinException.java
+++ b/src/main/java/in/koreatech/batch/_common/exception/custom/KoinException.java
@@ -1,0 +1,20 @@
+package in.koreatech.batch._common.exception.custom;
+
+public abstract class KoinException extends RuntimeException {
+
+    protected final String detail;
+
+    protected KoinException(String message) {
+        super(message);
+        this.detail = null;
+    }
+
+    protected KoinException(String message, String detail) {
+        super(message);
+        this.detail = detail;
+    }
+
+    public String getFullMessage() {
+        return String.format("%s %s", getMessage(), detail);
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/exception/custom/KoinIllegalArgumentException.java
+++ b/src/main/java/in/koreatech/batch/_common/exception/custom/KoinIllegalArgumentException.java
@@ -1,0 +1,18 @@
+package in.koreatech.batch._common.exception.custom;
+
+public class KoinIllegalArgumentException extends KoinException {
+
+    private static final String DEFAULT_MESSAGE = "잘못된 요청입니다.";
+
+    public KoinIllegalArgumentException(String message) {
+        super(message);
+    }
+
+    public KoinIllegalArgumentException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static KoinIllegalArgumentException withDetail(String detail) {
+        return new KoinIllegalArgumentException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/exception/custom/KoinIllegalStateException.java
+++ b/src/main/java/in/koreatech/batch/_common/exception/custom/KoinIllegalStateException.java
@@ -1,0 +1,18 @@
+package in.koreatech.batch._common.exception.custom;
+
+public class KoinIllegalStateException extends KoinException {
+
+    private static final String DEFAULT_MESSAGE = "서버에 문제가 생겼습니다.";
+
+    public KoinIllegalStateException(String message) {
+        super(message);
+    }
+
+    public KoinIllegalStateException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static KoinIllegalStateException withDetail(String detail) {
+        return new KoinIllegalStateException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/exception/custom/RequestTooFastException.java
+++ b/src/main/java/in/koreatech/batch/_common/exception/custom/RequestTooFastException.java
@@ -1,0 +1,8 @@
+package in.koreatech.batch._common.exception.custom;
+
+public class RequestTooFastException extends KoinException {
+
+    public RequestTooFastException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/in/koreatech/batch/_common/exception/package-info.java
+++ b/src/main/java/in/koreatech/batch/_common/exception/package-info.java
@@ -1,0 +1,6 @@
+@NonNullApi
+@NonNullFields
+package in.koreatech.batch._common.exception;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/src/main/java/in/koreatech/batch/domain/portal/client/PortalLoginClient.java
+++ b/src/main/java/in/koreatech/batch/domain/portal/client/PortalLoginClient.java
@@ -1,0 +1,101 @@
+package in.koreatech.batch.domain.portal.client;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.HttpCookie;
+import java.net.URI;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import in.koreatech.batch.domain.portal.exception.PortalLoginException;
+import in.koreatech.batch.domain.portal.repository.PortalLoginCookieRepository;
+import in.koreatech.batch.integration.config.PortalProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.FormBody;
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PortalLoginClient {
+
+    private final PortalLoginCookieRepository portalLoginCookieRepository;
+    private final PortalProperties portalProperties;
+    private final CookieManager cookieManager;
+    private final OkHttpClient okHttpClient;
+
+    public String getOrRefreshLoginCookie() {
+        return portalLoginCookieRepository.getLoginCookie()
+            .orElseGet(() -> {
+                String loginCookie;
+                try {
+                    loginCookie = getLoginCookie();
+                } catch (IOException e) {
+                    throw PortalLoginException.withDetail("아우누리 로그인 과정에서 문제가 발생했습니다.");
+                }
+                portalLoginCookieRepository.saveLoginCookie(loginCookie);
+                return loginCookie;
+            });
+    }
+
+    private String getLoginCookie() throws IOException {
+        Headers headers = new Headers.Builder()
+            .add("X-Forwarded-For", portalProperties.ip())
+            .add("X-Real-IP", portalProperties.ip())
+            .build();
+
+        okHttpClient.newCall(new Request.Builder()
+            .url(portalProperties.url().checkLoginId())
+            .headers(headers)
+            .post(
+                new FormBody.Builder()
+                    .add("login_id", portalProperties.id())
+                    .add("login_pwd", portalProperties.pw())
+                    .build()
+            )
+            .build()
+        ).execute().close();
+
+        cookieManager.getCookieStore().add(
+            URI.create(portalProperties.url().home()),
+            new HttpCookie("kut_login_type", "id")
+        );
+
+        okHttpClient.newCall(new Request.Builder()
+            .url(portalProperties.url().checkSecondLogin())
+            .headers(headers)
+            .post(
+                new FormBody.Builder()
+                    .add("login_id", portalProperties.id())
+                    .build()
+            )
+            .build()
+        ).execute().close();
+
+        okHttpClient.newCall(new Request.Builder()
+            .url(portalProperties.url().sso())
+            .headers(headers)
+            .post(RequestBody.create("", null))
+            .build()
+        ).execute().close();
+
+        okHttpClient.newCall(new Request.Builder()
+            .url(portalProperties.url().ssoLogin())
+            .headers(headers)
+            .get()
+            .build()
+        ).execute().close();
+
+        List<HttpCookie> cookies = cookieManager.getCookieStore().get(URI.create(portalProperties.url().home()));
+        return cookies.stream()
+            .filter(cookie -> portalProperties.cookie().equals(cookie.getName()))
+            .map(HttpCookie::getValue)
+            .findFirst()
+            .orElseThrow(() -> PortalLoginException.withDetail("아우누리 로그인 과정에서 문제가 발생했습니다."));
+    }
+}

--- a/src/main/java/in/koreatech/batch/domain/portal/exception/PortalLoginException.java
+++ b/src/main/java/in/koreatech/batch/domain/portal/exception/PortalLoginException.java
@@ -1,0 +1,19 @@
+package in.koreatech.batch.domain.portal.exception;
+
+import in.koreatech.batch._common.exception.custom.ExternalServiceException;
+
+public class PortalLoginException extends ExternalServiceException {
+    private static final String DEFAULT_MESSAGE = "아우누리 포털 로그인 과정에서 오류가 발생했습니다.";
+
+    public PortalLoginException(String message) {
+        super(message);
+    }
+
+    public PortalLoginException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static PortalLoginException withDetail(String detail) {
+        return new PortalLoginException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/batch/domain/portal/repository/PortalLoginCookieRepository.java
+++ b/src/main/java/in/koreatech/batch/domain/portal/repository/PortalLoginCookieRepository.java
@@ -1,0 +1,25 @@
+package in.koreatech.batch.domain.portal.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import in.koreatech.batch.integration.config.PortalProperties;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PortalLoginCookieRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final PortalProperties portalProperties;
+
+    public Optional<String> getLoginCookie() {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(portalProperties.cookie()));
+    }
+
+    public void saveLoginCookie(String cookieValue) {
+        redisTemplate.opsForValue().set(portalProperties.cookie(), cookieValue);
+    }
+}

--- a/src/main/java/in/koreatech/batch/integration/config/PortalProperties.java
+++ b/src/main/java/in/koreatech/batch/integration/config/PortalProperties.java
@@ -1,0 +1,22 @@
+package in.koreatech.batch.integration.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "portal")
+public record PortalProperties(
+    String id,
+    String pw,
+    String ip,
+    String cookie,
+    Url url
+) {
+    public record Url(
+        String home,
+        String checkFirstLogin,
+        String checkSecondLogin,
+        String sso,
+        String ssoLogin
+    ) {
+
+    }
+}

--- a/src/main/java/in/koreatech/batch/integration/config/PortalProperties.java
+++ b/src/main/java/in/koreatech/batch/integration/config/PortalProperties.java
@@ -12,7 +12,7 @@ public record PortalProperties(
 ) {
     public record Url(
         String home,
-        String checkFirstLogin,
+        String checkLoginId,
         String checkSecondLogin,
         String sso,
         String ssoLogin


### PR DESCRIPTION
# 🔥 연관 이슈

- close #5 

# 🚀 작업 내용

- 아우누리 포털 로그인 로직을 마이그레이션 했습니다.
  - 요청, 응답 과정에서 편리하게 구현할 수 있을 것 같아, okhttp 라이브러리를 사용했습니다.
  - 기존 파이썬으로 구현된 로직은 요청 URL이 모두 보여졌는데, 이를 숨기기 위해 `application-portal.yml` 파일에서 관리하도록 했습니다.
  - [문서](https://www.notion.so/1df9ae650b59809abbbff4097e2df475?pvs=4)

# 💬 리뷰 중점사항
향후 멀티 모듈을 위해 KOIN_API_V2에서 가져온 부분이 많습니다. 이 부분은 넘어가셔도 될 것 같습니다.
`domain/portal` 라이브러리를 중점으로 봐주시면 될 것 같습니다. 또한 패키지 위치가 적절한 지 한 번 확인 부탁드립니다..!