### PR TITLE
feat: 아우누리 포털 비밀번호 암호화 로직 추가

### DIFF
--- a/src/main/java/in/koreatech/batch/domain/portal/client/PortalLoginClient.java
+++ b/src/main/java/in/koreatech/batch/domain/portal/client/PortalLoginClient.java
@@ -59,7 +59,7 @@ public class PortalLoginClient {
             .post(
                 new FormBody.Builder()
                     .add("login_id", portalProperties.id())
-                    .add("login_pwd", portalProperties.pw())
+                    .add("login_pwd", portalProperties.securePw())
                     .build()
             )
             .build()

--- a/src/main/java/in/koreatech/batch/integration/config/PortalProperties.java
+++ b/src/main/java/in/koreatech/batch/integration/config/PortalProperties.java
@@ -1,5 +1,10 @@
 package in.koreatech.batch.integration.config;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "portal")
@@ -10,6 +15,20 @@ public record PortalProperties(
     String cookie,
     Url url
 ) {
+    public String securePw() {
+        String credsDir = System.getenv("CREDENTIALS_DIRECTORY");
+        if (credsDir == null) {
+            return this.pw;
+        }
+
+        try {
+            Path path = Paths.get(credsDir, "portal_password");
+            return Files.readString(path).trim();
+        } catch (IOException e) {
+            throw new RuntimeException("운영 환경에서 Portal 자격 증명을 로드하지 못했습니다.", e);
+        }
+    }
+
     public record Url(
         String home,
         String checkLoginId,


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

### 포털 비밀번호 암호화 로직 추가
- 기존 포털 비밀번호는 환경변수로 평문으로 관리
- 보안 이슈가 존재하여, `systemd-creds`를 통해 암호화

# 💬 리뷰 중점사항
